### PR TITLE
Escape expression in tests

### DIFF
--- a/test/test_trixi_test_nowarn.jl
+++ b/test/test_trixi_test_nowarn.jl
@@ -2,7 +2,7 @@ macro my_test_nowarn_string(expr, additional_ignore_content = [])
     quote
         add_to_additional_ignore_content = ["[ Info: hi"]
         append!($additional_ignore_content, add_to_additional_ignore_content)
-        @trixi_test_nowarn $expr $additional_ignore_content
+        @trixi_test_nowarn $(esc(expr)) $additional_ignore_content
     end
 end
 
@@ -10,7 +10,7 @@ macro my_test_nowarn_regex(expr, additional_ignore_content = [])
     quote
         add_to_additional_ignore_content = [r".*hi"]
         append!($additional_ignore_content, add_to_additional_ignore_content)
-        @trixi_test_nowarn $expr $additional_ignore_content
+        @trixi_test_nowarn $(esc(expr)) $additional_ignore_content
     end
 end
 
@@ -19,4 +19,6 @@ end
 
     @my_test_nowarn_string @info "hi"
     @my_test_nowarn_regex @info "hi"
+    a = 1.0
+    @my_test_nowarn_string println(a)
 end


### PR DESCRIPTION
While implementing TrixiTest.jl in Trixi.jl, I noticed we should escape `exp` in the custom macros. So I also added that in the tests. Without escaping in the new test `a` would not be known.