### PR TITLE
Add `at-test-allocations`

### DIFF
--- a/src/TrixiTest.jl
+++ b/src/TrixiTest.jl
@@ -7,7 +7,8 @@ include("auxiliary.jl")
 include("macros.jl")
 
 export get_kwarg, append_to_kwargs
-export @trixi_test_nowarn, @test_trixi_include_base, @timed_testset, @trixi_testset, @test_allocations
+export @trixi_test_nowarn, @test_trixi_include_base, @timed_testset, @trixi_testset,
+       @test_allocations
 
 # re-export methods from TrixiBase
 export mpi_isroot, trixi_include

--- a/src/TrixiTest.jl
+++ b/src/TrixiTest.jl
@@ -7,7 +7,7 @@ include("auxiliary.jl")
 include("macros.jl")
 
 export get_kwarg, append_to_kwargs
-export @trixi_test_nowarn, @test_trixi_include_base, @timed_testset, @trixi_testset
+export @trixi_test_nowarn, @test_trixi_include_base, @timed_testset, @trixi_testset, @test_allocations
 
 # re-export methods from TrixiBase
 export mpi_isroot, trixi_include

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -192,3 +192,19 @@ macro trixi_testset(name, expr)
         nothing
     end
 end
+
+"""
+    @test_allocations(mod, semi, sol, allocs)
+
+Test that the memory allocations of `mod.rhs!` are below `allocs`
+(e.g., from type instabilities), where `mod` is a module containing
+a method `rhs!(du, u, semi, t)`.
+"""
+macro test_allocations(mod, semi, sol, allocs)
+    quote
+        t = $(esc(sol)).t[end]
+        u = $(esc(sol)).u[end]
+        du = similar(u)
+        @test (@allocated $(esc(mod)).rhs!(du, u, $(esc(semi)), t)) < $(esc(allocs))
+    end
+end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -194,17 +194,17 @@ macro trixi_testset(name, expr)
 end
 
 """
-    @test_allocations(mod, semi, sol, allocs)
+    @test_allocations(rhs!, semi, sol, allocs)
 
-Test that the memory allocations of `mod.rhs!` are below `allocs`
-(e.g., from type instabilities), where `mod` is a module containing
+Test that the memory allocations of `rhs!` are below `allocs`
+(e.g., from type instabilities), where `rhs!` is a function with
 a method `rhs!(du, u, semi, t)`.
 """
-macro test_allocations(mod, semi, sol, allocs)
+macro test_allocations(rhs!, semi, sol, allocs)
     quote
         t = $(esc(sol)).t[end]
         u = $(esc(sol)).u[end]
         du = similar(u)
-        @test (@allocated $(esc(mod)).rhs!(du, u, $(esc(semi)), t)) < $(esc(allocs))
+        @test (@allocated $(esc(rhs!))(du, u, $(esc(semi)), t)) < $(esc(allocs))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ using TrixiTest
     include("test_testset.jl")
     include("test_test_trixi_include.jl")
     include("test_trixi_test_nowarn.jl")
+    include("test_test_allocations.jl")
 end

--- a/test/test_test_allocations.jl
+++ b/test/test_test_allocations.jl
@@ -2,7 +2,7 @@ module TestAllocations
 function rhs!(du, u, semi, t)
     # Simulate some computation
     du .= u .+ t
-    return du
+    return nothing
 end
 end
 

--- a/test/test_test_allocations.jl
+++ b/test/test_test_allocations.jl
@@ -1,0 +1,14 @@
+module TestAllocations
+    function rhs!(du, u, semi, t)
+        # Simulate some computation
+        du .= u .+ t
+        return du
+    end
+end
+
+@testset "@test_allocations" begin
+    semi = nothing
+    sol = (t = [1.0], u = [[1.0, 2.0]])
+    allocs = 1
+    @test_allocations(TestAllocations, semi, sol, allocs)
+end

--- a/test/test_test_allocations.jl
+++ b/test/test_test_allocations.jl
@@ -10,5 +10,5 @@ end
     semi = nothing
     sol = (t = [1.0], u = [[1.0, 2.0]])
     allocs = 1
-    @test_allocations(TestAllocations, semi, sol, allocs)
+    @test_allocations(TestAllocations.rhs!, semi, sol, allocs)
 end

--- a/test/test_test_allocations.jl
+++ b/test/test_test_allocations.jl
@@ -1,9 +1,9 @@
 module TestAllocations
-    function rhs!(du, u, semi, t)
-        # Simulate some computation
-        du .= u .+ t
-        return du
-    end
+function rhs!(du, u, semi, t)
+    # Simulate some computation
+    du .= u .+ t
+    return du
+end
 end
 
 @testset "@test_allocations" begin


### PR DESCRIPTION
In Trixi.jl, TrixiAtmo.jl, and TrixiShallowWater.jl we have a lot of code blocks like https://github.com/trixi-framework/Trixi.jl/blob/6b0f725604d7f63f8d7f778fdccbe57cfaab8a90/test/test_dgmulti_1d.jl#L22-L29 leading to a lot of code duplication. This PR adds a new macro, which allows to rewrite these blocks as `@test_allocations(Trixi, semi, sol, allocs)`. Note that we need to pass the module because the macro needs to know, which `rhs!` should be called. This is inspired by a macro I have in https://github.com/NumericalMathematics/DispersiveShallowWater.jl/blob/5f350c07ca20ce4df5e382c1db6d73475ae97fec/test/test_util.jl#L170-L177.