### PR TITLE
Escape `l2`, `linf`, `atol`, `rtol`

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -144,22 +144,29 @@ macro test_trixi_include_base(elixir, args...)
         # evaluate examples in the scope of the module they're called from
         @trixi_test_nowarn trixi_include(@__MODULE__, $(esc(elixir)); $(kwarg_exprs...)) $additional_ignore_content
 
-        # if present, compare l2 and linf errors against reference values
-        if !isnothing($l2) || !isnothing($linf)
+        # If present, compare l2 and linf errors against reference values.
+        # The reference values (and tolerances) are evaluated in the scope of the
+        # module the macro is called from, so that they may reference names that
+        # are only available there (e.g. `Double64` from a `using DoubleFloats`).
+        local l2_ref = $(esc(l2))
+        local linf_ref = $(esc(linf))
+        local atol_value = $(esc(atol))
+        local rtol_value = $(esc(rtol))
+        if !isnothing(l2_ref) || !isnothing(linf_ref)
             mod = @__MODULE__
             l2_measured, linf_measured = @invokelatest mod.analysis_callback(@invokelatest mod.sol)
 
-            if mpi_isroot() && !isnothing($l2)
-                @test length($l2) == length(l2_measured)
-                for (l2_expected, l2_actual) in zip($l2, l2_measured)
-                    @test isapprox(l2_expected, l2_actual, atol = $atol, rtol = $rtol)
+            if mpi_isroot() && !isnothing(l2_ref)
+                @test length(l2_ref) == length(l2_measured)
+                for (l2_expected, l2_actual) in zip(l2_ref, l2_measured)
+                    @test isapprox(l2_expected, l2_actual, atol = atol_value, rtol = rtol_value)
                 end
             end
 
-            if mpi_isroot() && !isnothing($linf)
-                @test length($linf) == length(linf_measured)
-                for (linf_expected, linf_actual) in zip($linf, linf_measured)
-                    @test isapprox(linf_expected, linf_actual, atol = $atol, rtol = $rtol)
+            if mpi_isroot() && !isnothing(linf_ref)
+                @test length(linf_ref) == length(linf_measured)
+                for (linf_expected, linf_actual) in zip(linf_ref, linf_measured)
+                    @test isapprox(linf_expected, linf_actual, atol = atol_value, rtol = rtol_value)
                 end
             end
         end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -159,14 +159,16 @@ macro test_trixi_include_base(elixir, args...)
             if mpi_isroot() && !isnothing(l2_ref)
                 @test length(l2_ref) == length(l2_measured)
                 for (l2_expected, l2_actual) in zip(l2_ref, l2_measured)
-                    @test isapprox(l2_expected, l2_actual, atol = atol_value, rtol = rtol_value)
+                    @test isapprox(l2_expected, l2_actual,
+                                   atol = atol_value, rtol = rtol_value)
                 end
             end
 
             if mpi_isroot() && !isnothing(linf_ref)
                 @test length(linf_ref) == length(linf_measured)
                 for (linf_expected, linf_actual) in zip(linf_ref, linf_measured)
-                    @test isapprox(linf_expected, linf_actual, atol = atol_value, rtol = rtol_value)
+                    @test isapprox(linf_expected, linf_actual,
+                                   atol = atol_value, rtol = rtol_value)
                 end
             end
         end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,11 +1,13 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TrixiBase = "9a0f1c46-06d5-4909-a5a3-ce25d3fa3284"
 
 [compat]
 Aqua = "0.8"
+DoubleFloats = "1.4"
 LinearAlgebra = "1"
 Test = "1"
 TrixiBase = "0.1.6"

--- a/test/test_test_trixi_include.jl
+++ b/test/test_test_trixi_include.jl
@@ -327,6 +327,40 @@ end
         end
     end
 
+    @trixi_testset "l2 and linf with DoubleFloats" begin
+        using DoubleFloats: Double64
+        example = """
+            function analysis_callback(sol)
+             return sol[1], sol[2]
+            end
+            sol = [1.0, 2.0]
+            """
+
+        mktemp() do path, io
+            write(io, example)
+            close(io)
+
+            @test_trixi_include(path, l2=Double64(1.0), linf=Double64(2.0))
+        end
+    end
+
+    @testset "l2 and linf with DoubleFloats and normal @testset" begin
+        using DoubleFloats: Double64
+        example = """
+            function analysis_callback(sol)
+             return sol[1], sol[2]
+            end
+            sol = [1.0, 2.0]
+            """
+
+        mktemp() do path, io
+            write(io, example)
+            close(io)
+
+            @test_trixi_include(path, l2=Double64(1.0), linf=Double64(2.0))
+        end
+    end
+
     @trixi_testset "l2 and linf with RealT_for_test_tolerances" begin
         example = """
             function analysis_callback(sol)


### PR DESCRIPTION
In trixi-framework/Trixi.jl#3096 I noticed a few failing tests due to undefined references to Double64 from DoubleFloats.jl or `Float128` from Quadmath.jl after switching from `@trixi_testset` to `@testitem`, when passing something like `Double64(...)` to `l2` or `linf`. I verified locally that escaping `l2`, `linf` (and `atol`, `rtol`) here fixes the tests in the Trixi.jl PR again.

The root cause is macro hygiene: unescaped reference values spliced into `@test_trixi_include_base` are resolved in the macro's definition module. With a plain `@testset` (or a `@testitem`) that module is the TrixiTest package, so `Double64(1.0)` is rewritten to `TrixiTest.Double64(...)`, which doesn't exist and therefore results in an `UndefVarError`.

When using a `@trixi_testset` this does not throw, because inside `@trixi_testset` we include macros.jl again:
https://github.com/trixi-framework/TrixiTest.jl/blob/1add15876559734ec25cd09ed3d84028f15f671c/src/macros.jl#L223
This redefines `@test_trixi_include_base` inside `TrixiTestModule`, so the value is instead resolved as `TrixiTestModule.Double64`. Because the testset body's `using DoubleFloats: Double64` also runs inside `TrixiTestModule`, that name is available there and resolution succeeds. Escaping makes the value evaluate in the caller's scope regardless, fixing both cases.

I also added a test using `@trixi_testset` for completeness. It was already succeeding before (in contrast to the test using a plain `@testset`).